### PR TITLE
Fix Markdown copied text

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
                             <code>{{ badge.imgUrl }}</code>
                             <h5>Markdown
                                 <button class="btn-flat waves-effect waves-teal clipboard"
-                                    v-bind:data-clipboard-text="'[![Downloads](' + badge.imgUrl + ')](https://brackets-extension-badges.github.io#' + extensionName + ')'">
+                                    v-bind:data-clipboard-text="'[![' + (badge.method === 'version' ? 'Version' : 'Downloads') + '](' + badge.imgUrl + ')](https://brackets-extension-badges.github.io#' + extensionName + ')'">
                                     <i class="material-icons">content_copy</i>
                                 </button>
                             </h5>


### PR DESCRIPTION
Thanks for implementing https://github.com/brackets-extension-badges/brackets-extension-badges.github.io/issues/2 so quickly.

The markdown displayed in the modal is correct, but the markdown copied always gets the text "Downloads".